### PR TITLE
resolveBodyFromRequest

### DIFF
--- a/src/main/java/org/lili/RequestFilter.java
+++ b/src/main/java/org/lili/RequestFilter.java
@@ -49,7 +49,7 @@ public class RequestFilter implements GatewayFilter, Ordered {
      * 但是在spring-boot-starter-parent 2.1.0.RELEASE + Spring Cloud Greenwich.M3 body 中不生效，总是为空
      *
      * @param serverHttpRequest
-     * @return
+     * @return 
      */
     private String resolveBodyFromRequest(ServerHttpRequest serverHttpRequest) {
         Flux<DataBuffer> body = serverHttpRequest.getBody();


### PR DESCRIPTION
#resolveBodyFromRequest 我用这种方法在2.0.5中失败了， 针对post请求，连续两次post请求，加了获取body然后将body重新包装成一个exchange的时候，第二次请求并不会透传，二十返回了400（bad_request）